### PR TITLE
Add PricelistItems repo and ResetItems method

### DIFF
--- a/GS_OmniChannelSystem.Rest.SDK/Client/ContextUOW.cs
+++ b/GS_OmniChannelSystem.Rest.SDK/Client/ContextUOW.cs
@@ -455,6 +455,14 @@ namespace GS.OmniChannelSystem.Rest.SDK.Client
             }
         }
 
+        public IPricelistItemsRepository PricelistItems
+        {
+            get
+            {
+                return new PricelistItemsRepository(this.Context);
+            }
+        }
+
         public ICategoriesRepository Categories
         {
             get

--- a/GS_OmniChannelSystem.Rest.SDK/Client/PricelistItemsRepository.cs
+++ b/GS_OmniChannelSystem.Rest.SDK/Client/PricelistItemsRepository.cs
@@ -1,0 +1,80 @@
+﻿using GS.OmniChannelSystem.Rest.SDK.Interfaces;
+using GS.OmniChannelSystem.Rest.SDK.Models;
+
+namespace GS.OmniChannelSystem.Rest.SDK.Client
+{
+    public class PricelistItemsRepository : BaseRepository<PricelistItem, PricelistItem.Summary>, IPricelistItemsRepository
+    {
+        public PricelistItemsRepository(Context context)
+            : base(context, "api/pricelistitems")
+        {
+
+        }
+
+        /// <summary>
+        /// Adds a single item to a pricelist without removing existing items.
+        ///
+        /// How it works:
+        ///   A POST request is sent to api/pricelistitems with the PricelistItem payload.
+        ///   The Pricelist property is set as an EntityReference to the target pricelist,
+        ///   so the server assigns the new item to that pricelist.
+        ///   Existing items on the pricelist remain untouched.
+        ///
+        /// API endpoint: POST api/pricelistitems
+        /// Request body: { "Pricelist": { "ID": pricelistId }, "Article": ..., "Keys": [...] }
+        ///
+        /// Reference: PricelistItemsController.Post + Api.Models.PricelistItem
+        /// </summary>
+        /// <param name="pricelistId">The ID of the target pricelist.</param>
+        /// <param name="item">The PricelistItem to add (including Keys and Prices).</param>
+        /// <returns>The created PricelistItem as returned by the server.</returns>
+        public PricelistItem AddItem(long pricelistId, PricelistItem item)
+        {
+            item.Pricelist = new EntityReference { ID = pricelistId };
+            return this.Create(item);
+        }
+
+        /// <summary>
+        /// Adds a single item to a pricelist (identified by External_Key) without removing existing items.
+        ///
+        /// How it works:
+        ///   Same as AddItem(long, PricelistItem), but the pricelist is resolved server-side
+        ///   via External_Key instead of ID (using GetByEntityReference).
+        ///
+        /// API endpoint: POST api/pricelistitems
+        /// Request body: { "Pricelist": { "External_Key": externalKey }, "Article": ..., "Keys": [...] }
+        ///
+        /// Reference: PricelistItemsController.Post + GetByEntityReference(ID, External_Key)
+        /// </summary>
+        /// <param name="externalKey">The External_Key of the target pricelist.</param>
+        /// <param name="item">The PricelistItem to add (including Keys and Prices).</param>
+        /// <returns>The created PricelistItem as returned by the server.</returns>
+        public PricelistItem AddItem(string externalKey, PricelistItem item)
+        {
+            item.Pricelist = new EntityReference { External_Key = externalKey };
+            return this.Create(item);
+        }
+
+        /// <summary>
+        /// Retrieves all items of a specific pricelist (paginated).
+        ///
+        /// How it works:
+        ///   A GET request is sent to api/pricelistitems with the filter parameter "pricelistid".
+        ///   The server filters items by the given pricelist ID.
+        ///
+        /// API endpoint: GET api/pricelistitems?search=...&amp;pageIndex=...&amp;pageSize=...&amp;orderBy=...&amp;filter=pricelistid%3D{pricelistId}
+        ///
+        /// Reference: PricelistItemsController.toFilteredQuery (filter key: "pricelistid")
+        /// </summary>
+        /// <param name="pricelistId">The ID of the pricelist to query items for.</param>
+        /// <param name="search">Optional search term.</param>
+        /// <param name="pageIndex">Zero-based page index.</param>
+        /// <param name="pageSize">Number of items per page.</param>
+        /// <param name="orderBy">Sort expression.</param>
+        /// <returns>A paginated list of PricelistItem summaries.</returns>
+        public Paginated<PricelistItem.Summary> FindByPricelist(long pricelistId, string search, int pageIndex, int pageSize, string orderBy)
+        {
+            return this.FindAll(search, pageIndex, pageSize, orderBy, "pricelistid=" + pricelistId);
+        }
+    }
+}

--- a/GS_OmniChannelSystem.Rest.SDK/Client/PricelistsRepository.cs
+++ b/GS_OmniChannelSystem.Rest.SDK/Client/PricelistsRepository.cs
@@ -1,4 +1,5 @@
 ﻿using GS.OmniChannelSystem.Rest.SDK.Interfaces;
+using GS.OmniChannelSystem.Rest.SDK.Models;
 
 namespace GS.OmniChannelSystem.Rest.SDK.Client
 {
@@ -7,7 +8,28 @@ namespace GS.OmniChannelSystem.Rest.SDK.Client
         public PricelistsRepository(Context context)
             :base(context, "api/pricelists")
         {
-            
+
+        }
+
+        /// <summary>
+        /// Resets all items of a pricelist by sending Items as null.
+        ///
+        /// How it works:
+        ///   A PUT request is sent to the pricelist with the "Items" property explicitly set to null.
+        ///   The server interprets this as an instruction to remove all existing PricelistItems
+        ///   (including subordinate PricelistKeys and PricelistPrices).
+        ///
+        /// API endpoint: PUT api/pricelists/{id}?properties=Items
+        /// Request body: { "Items": null }
+        ///
+        /// Reference: PricelistsController (BaseRepositoryApiController) + Api.Models.Pricelist.Items
+        /// </summary>
+        /// <param name="id">The ID of the pricelist whose items should be reset.</param>
+        /// <returns>The updated pricelist after the reset.</returns>
+        public Pricelist ResetItems(long id)
+        {
+            var entity = new Pricelist { Items = null };
+            return this.Update(id, entity, new[] { "Items" });
         }
     }
 }

--- a/GS_OmniChannelSystem.Rest.SDK/Interfaces/IPricelistItemsRepository.cs
+++ b/GS_OmniChannelSystem.Rest.SDK/Interfaces/IPricelistItemsRepository.cs
@@ -1,0 +1,37 @@
+﻿using GS.OmniChannelSystem.Rest.SDK.Models;
+
+namespace GS.OmniChannelSystem.Rest.SDK.Interfaces
+{
+    public interface IPricelistItemsRepository : IRepository<PricelistItem, PricelistItem.Summary>
+    {
+        /// <summary>
+        /// Adds a single item to a pricelist without removing existing items.
+        /// The item is created via POST api/pricelistitems with the Pricelist reference set.
+        /// </summary>
+        /// <param name="pricelistId">The ID of the target pricelist.</param>
+        /// <param name="item">The PricelistItem to add (including Keys and Prices).</param>
+        /// <returns>The created PricelistItem as returned by the server.</returns>
+        PricelistItem AddItem(long pricelistId, PricelistItem item);
+
+        /// <summary>
+        /// Adds a single item to a pricelist (identified by External_Key) without removing existing items.
+        /// The item is created via POST api/pricelistitems with the Pricelist reference set by External_Key.
+        /// </summary>
+        /// <param name="externalKey">The External_Key of the target pricelist.</param>
+        /// <param name="item">The PricelistItem to add (including Keys and Prices).</param>
+        /// <returns>The created PricelistItem as returned by the server.</returns>
+        PricelistItem AddItem(string externalKey, PricelistItem item);
+
+        /// <summary>
+        /// Retrieves all items of a specific pricelist (paginated).
+        /// Uses the server-side filter "pricelistid" on GET api/pricelistitems.
+        /// </summary>
+        /// <param name="pricelistId">The ID of the pricelist to query items for.</param>
+        /// <param name="search">Optional search term.</param>
+        /// <param name="pageIndex">Zero-based page index.</param>
+        /// <param name="pageSize">Number of items per page.</param>
+        /// <param name="orderBy">Sort expression.</param>
+        /// <returns>A paginated list of PricelistItem summaries.</returns>
+        Paginated<PricelistItem.Summary> FindByPricelist(long pricelistId, string search, int pageIndex, int pageSize, string orderBy);
+    }
+}

--- a/GS_OmniChannelSystem.Rest.SDK/Interfaces/IPricelistsRepository.cs
+++ b/GS_OmniChannelSystem.Rest.SDK/Interfaces/IPricelistsRepository.cs
@@ -2,5 +2,12 @@
 {
     public interface IPricelistsRepository : IRepository<GS.OmniChannelSystem.Rest.SDK.Models.Pricelist, GS.OmniChannelSystem.Rest.SDK.Models.Pricelist.Summary>
     {
+        /// <summary>
+        /// Resets all items of a pricelist by sending Items as null.
+        /// All existing PricelistItems (including PricelistKeys and PricelistPrices) are removed server-side.
+        /// </summary>
+        /// <param name="id">The ID of the pricelist whose items should be reset.</param>
+        /// <returns>The updated pricelist without items.</returns>
+        GS.OmniChannelSystem.Rest.SDK.Models.Pricelist ResetItems(long id);
     }
 }

--- a/GS_OmniChannelSystem.Rest.SDK/Interfaces/IUnitOfWork.cs
+++ b/GS_OmniChannelSystem.Rest.SDK/Interfaces/IUnitOfWork.cs
@@ -60,6 +60,7 @@ namespace GS.OmniChannelSystem.Rest.SDK.Interfaces
         ICurrenciesRepository Currencies { get; }
         ICacheRepository Cache { get; }
         IChainStoresRepository ChainStores { get; }
+        IPricelistItemsRepository PricelistItems { get; }
 
         string Files(long fileId, int width, int height, StretchMode? stretchMode = StretchMode.ProportionalExact);
         string Files(long fileId);


### PR DESCRIPTION
Introduce PricelistItems support: add IPricelistItemsRepository and PricelistItemsRepository (AddItem by ID or External_Key, FindByPricelist paginated query) and expose PricelistItems via IUnitOfWork/ContextUOW. Implement PricelistsRepository.ResetItems to clear all items by updating Items = null (uses PUT properties=Items). Minor namespace/usings update in PricelistsRepository. This enables creating individual pricelist items without removing existing ones and resetting all items on a pricelist server-side.